### PR TITLE
Resolve build error due to missing IconWarning

### DIFF
--- a/src/renderer/src/components/icon/index.tsx
+++ b/src/renderer/src/components/icon/index.tsx
@@ -31,3 +31,4 @@ export { default as IconTopPane } from "./files/IconTopPane";
 export { default as IconUserCircle } from "./files/IconUserCircle";
 export { default as IconViewfinder } from "./files/IconViewfinder";
 export { default as IconApiSync } from "./files/IconApiSync";
+export { default as IconWarning } from "./files/IconWarning";


### PR DESCRIPTION
Build error occurred due to `IconWarning` missing at `icon/index.tsx` export group.
This PR fix this issue.